### PR TITLE
Patch to enable building on Mac OSX.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,8 +48,17 @@ if [ $1 == 'FreeBSD' -o $1 == 'freebsd' ]
     strip oathgen_freebsd_$(uname -m)
 fi
 
-if [ $1 == 'Mac' -o $1 == 'mac' ]
-    then echo nothing yet
+if [ $1 == 'Mac' -o $1 == 'mac' ]; then
+    if [ ! -f /usr/local/lib/libcryptopp.a ]; then
+      echo "/usr/local/lib/libcryptopp.a not found."
+      echo "Have you installed it, e.g. via brew?"
+    fi
+    g++ -std=c++11 -Wall -Wextra -Werror \
+    -Weffc++ -pedantic-errors main.cpp \
+    -isystem /usr/local/include \
+    -o oathgen_mac \
+    /usr/local/lib/libcryptopp.a
+    strip oathgen_mac
 fi
 
 if [ $1 == 'Windows' -o $1 == 'windows' ]

--- a/strings.hpp
+++ b/strings.hpp
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <string>
 
-#include <cryptopp/alt_base32.h>
+#include <cryptopp/base32.h>
 #include <cryptopp/hex.h>
 
 #include "global.hpp"
@@ -71,7 +71,7 @@ const std::string decode( const std::string& secret, const bool hex_encode )
 
     else
     {
-        CryptoPP::AltBase32Decoder b32decoder;
+        CryptoPP::Base32Decoder b32decoder;
         b32decoder.Attach( new CryptoPP::StringSink( decoded ) );
         b32decoder.Put( (std::uint8_t*)secret.c_str(), secret.size() );
         b32decoder.MessageEnd();


### PR DESCRIPTION
I think the use of the base32 package that ships with current Crypto++ versions is a general (non-OSX-specific) improvement, but it does help with building on OSX without a bunch of manual compiles of dependencies. I was able to build and run with the proposed patches using simply:

    brew install cryptopp
    ./build.sh mac
